### PR TITLE
Add sub-navigation to root route and preserve active sub-route when switching budgets

### DIFF
--- a/packages/web/app/components/budget-navigation.tsx
+++ b/packages/web/app/components/budget-navigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { SignOut } from "./login";
-import { useParams } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { Budget } from "common-ts";
 
 type Props = {
@@ -12,7 +12,22 @@ type Props = {
 const BudgetNavigation = ({ budgets, loggedIn }: Props) => {
   const signOut = loggedIn ? <SignOut /> : "";
   const params = useParams();
+  const pathname = usePathname();
   const currentBudgetId = params ? params.budgetUuid : "";
+
+  // Extract the sub-route from current pathname to preserve it when switching budgets
+  const getSubRoute = () => {
+    if (pathname === "/") return "";
+
+    // Match patterns like /budgets/[uuid]/subpath
+    const match = pathname.match(/^\/budgets\/[^\/]+\/(.+)$/);
+    return match ? `/${match[1]}` : "";
+  };
+
+  const getBudgetHref = (budgetUuid: string) => {
+    const subRoute = getSubRoute();
+    return `/budgets/${budgetUuid}${subRoute}`;
+  };
 
   const getActiveClass = (budgetId: string) =>
     `link ${currentBudgetId === budgetId ? "active" : ""}`;
@@ -44,7 +59,7 @@ const BudgetNavigation = ({ budgets, loggedIn }: Props) => {
               <li className="mr-6" key={budget.uuid}>
                 <Link
                   className={getActiveClass(budget.uuid)}
-                  href={`/budgets/${budget.uuid}`}
+                  href={getBudgetHref(budget.uuid)}
                 >
                   {budget.name}
                 </Link>
@@ -62,7 +77,7 @@ const BudgetNavigation = ({ budgets, loggedIn }: Props) => {
             <li className="mr-6" key={budget.uuid}>
               <Link
                 className={getActiveClass(budget.uuid)}
-                href={`/budgets/${budget.uuid}`}
+                href={getBudgetHref(budget.uuid)}
               >
                 {budget.name}
               </Link>

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import BudgetPage from "./components/budget-page";
+import BudgetSubNavigation from "./components/budget-sub-navigation";
 import {
   getLoggedInUserPreferredBudgetId as getLoggedInUserPreferredBudgetUuid,
   isYnabTokenExpired
@@ -20,5 +21,10 @@ export default async function Home() {
   if (!budgetUuid) {
     return <div>No budgets found</div>;
   }
-  return <BudgetPage budgetUuid={budgetUuid} />;
+  return (
+    <>
+      <BudgetSubNavigation budgetUuid={budgetUuid} />
+      <BudgetPage budgetUuid={budgetUuid} />
+    </>
+  );
 }


### PR DESCRIPTION
## Features Implemented

### 1. Sub-navigation on Root Route
- Added `BudgetSubNavigation` component to the root route (`/`) to match the behavior of budget-specific routes
- Now the root route shows the same view as `/budgets/[budgetId]` with the sub-navigation (Overview, Transactions, Predictions, AI Assistant)

### 2. Preserve Active Sub-route When Switching Budgets
- Modified `BudgetNavigation` component to preserve the current sub-route when switching between budgets
- When user is on `/budgets/1b443ebf-ea07-4ab7-8fd5-9330bf80608c/uncategorised` and switches to another budget, they will land on the uncategorised page of the new budget
- Uses pathname parsing to extract the sub-route and apply it to budget navigation links

## Technical Changes

### Modified Files:
1. **`packages/web/app/page.tsx`**
   - Added `BudgetSubNavigation` import and component
   - Wrapped `BudgetPage` with sub-navigation to match budget-specific routes

2. **`packages/web/app/components/budget-navigation.tsx`**
   - Added `usePathname` hook to track current route
   - Implemented `getSubRoute()` function to extract sub-route from pathname
   - Implemented `getBudgetHref()` function to construct budget links with preserved sub-route
   - Updated all budget navigation links to use the new href generation

## User Experience Improvements

- **Consistent Navigation**: Root route now has the same navigation experience as budget-specific routes
- **Seamless Budget Switching**: Users can switch between budgets while staying in the same view (e.g., AI Assistant)
- **Improved Workflow**: No need to re-navigate to desired section after switching budgets

## Testing

- Development server runs successfully
- TypeScript compilation passes
- Navigation logic handles edge cases (root route, missing sub-routes)

This implementation follows the existing codebase patterns and maintains backward compatibility while adding the requested navigation enhancements.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author