### PR TITLE
Fix auto-refresh for uncategorised page by adding revalidatePath calls

### DIFF
--- a/packages/web/app/budgets/[budgetUuid]/uncategorised/actions.ts
+++ b/packages/web/app/budgets/[budgetUuid]/uncategorised/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import {
   applyCategories as applyCategoriesApi,
   applyAllCategories as applyAllCategoriesApi,
@@ -16,7 +17,12 @@ import {
 
 export async function applyCategories(budgetId: string, transactions: any[]) {
   try {
-    return await applyCategoriesApi(budgetId, transactions);
+    const result = await applyCategoriesApi(budgetId, transactions);
+
+    // Invalidate the cache for the uncategorised page
+    revalidatePath(`/budgets/${budgetId}/uncategorised`);
+
+    return result;
   } catch (error) {
     console.error("Error applying categories:", error);
     throw error;
@@ -25,7 +31,12 @@ export async function applyCategories(budgetId: string, transactions: any[]) {
 
 export async function applyAllCategories(budgetId: string) {
   try {
-    return await applyAllCategoriesApi(budgetId);
+    const result = await applyAllCategoriesApi(budgetId);
+
+    // Invalidate the cache for the uncategorised page
+    revalidatePath(`/budgets/${budgetId}/uncategorised`);
+
+    return result;
   } catch (error) {
     console.error("Error applying all categories:", error);
     throw error;
@@ -64,12 +75,17 @@ export async function applySingleCategory(
   isManualChange: boolean = false
 ) {
   try {
-    return await applySingleCategoryApi(
+    const result = await applySingleCategoryApi(
       budgetId,
       transactionId,
       categoryName,
       isManualChange
     );
+
+    // Invalidate the cache for the uncategorised page
+    revalidatePath(`/budgets/${budgetId}/uncategorised`);
+
+    return result;
   } catch (error) {
     console.error("Error applying single category:", error);
     throw error;
@@ -81,7 +97,12 @@ export async function approveSingleTransaction(
   transactionId: string
 ) {
   try {
-    return await approveSingleTransactionApi(budgetId, transactionId);
+    const result = await approveSingleTransactionApi(budgetId, transactionId);
+
+    // Invalidate the cache for the uncategorised page
+    revalidatePath(`/budgets/${budgetId}/uncategorised`);
+
+    return result;
   } catch (error) {
     console.error("Error approving single transaction:", error);
     throw error;
@@ -90,7 +111,12 @@ export async function approveSingleTransaction(
 
 export async function approveAllTransactions(budgetId: string) {
   try {
-    return await approveAllTransactionsApi(budgetId);
+    const result = await approveAllTransactionsApi(budgetId);
+
+    // Invalidate the cache for the uncategorised page
+    revalidatePath(`/budgets/${budgetId}/uncategorised`);
+
+    return result;
   } catch (error) {
     console.error("Error approving all transactions:", error);
     throw error;


### PR DESCRIPTION
## Problem

The AI assistant (uncategorised page) had a data refresh issue where applying categories or approving transactions didn't update the table data immediately. Users had to manually refresh the page to see changes.

**Root Cause:** The uncategorised page only used client-side state management without server-side cache invalidation, unlike the prediction page which works correctly.

## Solution

Added `revalidatePath()` calls to all data-modifying actions in the uncategorised page to match the successful pattern used in the predictions page.

## Changes Made

- ✅ Added `revalidatePath()` to `applyCategories` - Apply selected categories
- ✅ Added `revalidatePath()` to `applyAllCategories` - Apply all categories  
- ✅ Added `revalidatePath()` to `applySingleCategory` - Apply single category
- ✅ Added `revalidatePath()` to `approveSingleTransaction` - Approve single transaction
- ✅ Added `revalidatePath()` to `approveAllTransactions` - Approve all transactions

## Expected Behavior After Fix

- ✅ Immediate data refresh when clicking "Apply" or "Apply All" on uncategorized transactions
- ✅ Immediate data refresh when approving transactions in the unapproved tab
- ✅ Table shows updated data without requiring full page reload
- ✅ Consistent behavior matching the prediction page

## Technical Details

The fix ensures proper server-side cache invalidation by calling `revalidatePath(`/budgets/${budgetId}/uncategorised`)` after each successful API operation, which tells Next.js to refresh the server-rendered data for that route.

## Testing

- [x] Code compiles without errors
- [x] Logic tested with mock functions
- [x] Follows the same pattern as working prediction page

**Ready for testing:** Please test the apply/approve functionality to verify immediate data refresh.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author